### PR TITLE
feat: add out_file option to create a file for decryption

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,13 @@ inputs:
   private_key:
     description: "Private key needed to decrypt action"
     required: false
+  out_file:
+    description: "File path to an out json file that should be use to place the decrypted content of the ejson"
+    required: false
 
 outputs:
   decrypted:
-    description: "List of changes made to the secret"
+    description: "Decrypted JSON content"
 
 runs:
   using: "docker"

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const main = async () => {
     core.getInput("action"),
     core.getInput("file_path"),
     core.getInput("private_key"),
+    core.getInput("out_file"),
   );
 
   try {

--- a/src/Action.js
+++ b/src/Action.js
@@ -11,6 +11,7 @@ export default class Action {
   #action;
   #filePath;
   #privateKey;
+  #outFile;
 
   /**
    * Create a new Action instance.
@@ -19,12 +20,13 @@ export default class Action {
    * @param {string} filePath The path to the JSON file.
    * @param {string} privateKey Optional private key for encryption.
    */
-  constructor(action, filePath, privateKey = "") {
+  constructor(action, filePath, privateKey = "", outFile = "") {
     this.exec = util.promisify(cp.exec);
 
     this.#action = action;
     this.#filePath = filePath;
     this.#privateKey = privateKey;
+    this.#outFile = outFile;
 
     this.#validate();
   }
@@ -103,6 +105,10 @@ export default class Action {
 
     if (!lodash.isEmpty(err)) {
       throw new Error(err);
+    }
+
+    if (!lodash.isEmpty(this.#outFile)) {
+      fs.writeFileSync(this.#outFile, out, "utf-8");
     }
 
     core.setOutput("decrypted", out);


### PR DESCRIPTION
## Description

New config to create an optional file for decryption otput instend of just the step output variable

## Task Context

### What is the current behavior?

- To get the decrypted content of a file we should use the `decrypted` out variable of the step where whe run the decryption

### What is the new behavior?

- Now we can set a new config `out_file` for the decryption action that stores the decrypted content directly to a file instead of get the row text as a variable

### Additional Context

<!-- Add here any additional context you think is important. -->
