### PR TITLE
fix: finish process with error if commands fail by any reason

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,11 @@ const main = async () => {
   try {
     await action.run();
   } catch (e) {
-    core.error(e);
+    core.error(
+      `[ERROR] Failure on ejson ${core.getInput("action")}: ${e.message}`,
+    );
+
+    process.exit(1);
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ejson-action",
-  "version": "0.0.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ejson-action",
-      "version": "0.0.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",


### PR DESCRIPTION
## Description

Fail to execute any action is not properly reflected on action status

## Task Context

### What is the current behavior?

If ejson execution fails the action actually do not fail

### What is the new behavior?

If ejson execution fails the error is properly handled to the status of the action

### Additional Context

<!-- Add here any additional context you think is important. -->
