### PR TITLE
feat: add build and pusblish in registry job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ env:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   bump_version:
@@ -21,14 +22,14 @@ jobs:
       version: ${{ steps.cz.outputs.version }}
     steps:
       - name: Check out
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: "${{ secrets.ACCESS_TOKEN }}"
           ref: "main"
 
       - name: Set up Python
-        uses: actions/setup-python@v4.7.0
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: 3.11
 
@@ -57,3 +58,15 @@ jobs:
 
       - name: Print Version
         run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v4
+      - name: Set up buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Build and push
+        run: |
+          docker buildx build --platform linux/amd64,linux/arm64 -t $(echo "ghcr.io/${{ github.repository }}:latest" | tr '[:upper:]' '[:lower:]') --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:20
 
+LABEL "com.github.actions.icon"="blue"
+LABEL "com.github.actions.color"="database"
+LABEL "com.github.actions.name"="ejson action"
+LABEL "com.github.actions.description"="Execute encryption and decryption of json files using ejson"
+LABEL "org.opencontainers.image.source"="https://github.com/Drafteame/ejson-action"
+
 RUN curl -sLo ejson.tar.gz https://github.com/Shopify/ejson/releases/download/v1.4.1/ejson_1.4.1_linux_amd64.tar.gz && \
   tar xfvz ejson.tar.gz && \
   mv ejson /usr/local/bin/ && \


### PR DESCRIPTION
## Description

Se agrega en el workflow de release el job para la publicación en el container Registry del repo.

Con esto nos ahorramos el tiempo de build de la imagen de Docker en los workflows de deploy ya que quedan previamente publicadas.

Se valida su funcionamiento en dev:
<img width="876" alt="image" src="https://github.com/Drafteame/ejson-action/assets/57784749/6be463b0-b5e0-4b7f-9461-06ea62178b1c">


## Task Context

### What is the current behavior?

<!-- current functionality without PR -->

### What is the new behavior?

<!-- expected functionality with PR -->

### Additional Context

<!-- Add here any additional context you think is important. -->
